### PR TITLE
Specify encoding when opening the config/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Use [pip](https://pip.pypa.io/en/stable/) to install the application.
 pip install wikicodename
 ```
 
-**Warning!** On Windows you may need to set the `PYTHONUTF8` environmental
-variable to `1` for the application to work properly.
-
 ## Usage
 
 Use `wikicodename` command to generate a list of code names for the default

--- a/wikicodename/cache.py
+++ b/wikicodename/cache.py
@@ -31,7 +31,7 @@ class Cache:
         data = None
         file_path = self.__get_file_path(id)
         try:
-            file = open(file_path, 'r')
+            file = open(file_path, 'r', encoding='utf8')
             data = file.read()
             file.close()
         except FileNotFoundError:
@@ -44,7 +44,7 @@ class Cache:
     def write(self, id: str, data: str):
         file_path = self.__get_file_path(id)
         try:
-            file = open(file_path, 'w')
+            file = open(file_path, 'w', encoding='utf8')
             file.write(data)
             file.close()
         except OSError as e:

--- a/wikicodename/config.py
+++ b/wikicodename/config.py
@@ -53,7 +53,7 @@ class Config:
 
     def __load_file(self, file_path: str) -> dict:
         try:
-            file = open(file_path, 'r')
+            file = open(file_path, 'r', encoding='utf8')
             data = yaml.load(file, Loader=yaml.SafeLoader)
             file.close()
             if not isinstance(data, dict):


### PR DESCRIPTION
This eliminates the potential need for the environment variable.

I did a loose test on Ubuntu and Windows.